### PR TITLE
Create POST API for adding payee

### DIFF
--- a/.devcontainer/.env
+++ b/.devcontainer/.env
@@ -3,3 +3,4 @@ POSTGRES_PASSWORD=postgres
 POSTGRES_DB=postgres
 POSTGRES_HOSTNAME=postgres
 TEST_DATABASE_URL="postgres://postgres:postgres@db:5432/postgres?sslmode=disable"
+

--- a/.devcontainer/.env
+++ b/.devcontainer/.env
@@ -1,6 +1,2 @@
-POSTGRES_USER=postgres
-POSTGRES_PASSWORD=postgres
-POSTGRES_DB=postgres
-POSTGRES_HOSTNAME=postgres
 TEST_DATABASE_URL="postgres://postgres:postgres@db:5432/postgres?sslmode=disable"
 

--- a/.devcontainer/.env
+++ b/.devcontainer/.env
@@ -1,2 +1,6 @@
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=postgres
+POSTGRES_DB=postgres
+POSTGRES_HOSTNAME=postgres
 TEST_DATABASE_URL="postgres://postgres:postgres@db:5432/postgres?sslmode=disable"
 

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 volumes:
   postgres-data:
 

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -10,6 +10,7 @@ services:
       dockerfile: Dockerfile
     env_file:
         - ./.env
+
     volumes:
       - ../..:/workspaces:cached
     command: sleep infinity

--- a/.github/workflows/payoutManagementSystem.yml
+++ b/.github/workflows/payoutManagementSystem.yml
@@ -16,7 +16,6 @@ jobs:
         with:
           go-version: ${{ env.GO-VERSION }}
           cache-dependency-path: go.sum
-
   format:
     name: Check format
     runs-on: ubuntu-24.04
@@ -39,7 +38,7 @@ jobs:
         uses: golangci/golangci-lint-action@v7
         with:
           version: v2.4.0
-
+  
   test:
     runs-on: ubuntu-24.04
     needs: lint
@@ -59,3 +58,4 @@ jobs:
           # TODO: SOLVE: POST JOB CLEANUP: Error: imageName is required to push images
           # TODO: create acess token in ghcr and cache image for faster workflow
           runCmd: go test -v ./...
+

--- a/.github/workflows/payoutManagementSystem.yml
+++ b/.github/workflows/payoutManagementSystem.yml
@@ -57,5 +57,6 @@ jobs:
         with:
           # TODO: SOLVE: POST JOB CLEANUP: Error: imageName is required to push images
           # TODO: create acess token in ghcr and cache image for faster workflow
+          env: ./.env
           runCmd: go test -v ./...
 

--- a/.github/workflows/payoutManagementSystem.yml
+++ b/.github/workflows/payoutManagementSystem.yml
@@ -57,6 +57,5 @@ jobs:
         with:
           # TODO: SOLVE: POST JOB CLEANUP: Error: imageName is required to push images
           # TODO: create acess token in ghcr and cache image for faster workflow
-          env: ./.env
           runCmd: go test -v ./...
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ Clone this repo: <a href = "https://github.com/Swarathmica-infraspec/payout-mana
 GO-VERSION: 1.25.0
 
 The project contains payoutmanagementsystem/ <br>
-
 - .github/workflows/payoutManagementSystem.yml <br>
 - payee/
   - payee.go <br>
@@ -44,7 +43,7 @@ This will start PostgreSQL in a container.
 
 To start devcontainer using terminal:
 in your project root, run,
-devcontainer up --workspace-folder
+devcontainer up --workspace-folder .
 
 To get into the container:
 devcontainer exec --workspace-folder . bash
@@ -53,26 +52,20 @@ devcontainer exec --workspace-folder . bash
 ## 2. Create Payees Table
 
 Run the below command for the first time (or if db does not exist):
+
 psql -h db -U $POSTGRES_USER -d $POSTGRES_DB -f payee/payee_db.sql
 
 It will prompt for password. Give your postgres password. (or refer to .env)
 
-If 'command not found: psql' : run : sudo apt-get update
-                                     sudo apt-get install -y postgresql-client
+If 'command not found: psql' : run : apt-get update
+                                     apt-get install -y postgresql-client
 
 ## 3. Data Access Object
 
 payeeDAO contains database query for payee and payeeDAO_test contains relevant tests
 
 ## 4. HTTP API Usage
-
-since postgres is run from docker, 
-
-docker exec -it devcontainer-app-1 bash
-
-cd /workspaces/payoutManagementSystem
-
-then run: go run main.go #entry point
+run: go run main.go #entry point
 
 payeeApi.go has the code for API while payeeAPI_test.go has test code
 
@@ -97,12 +90,19 @@ expected response: {'id':1}
 
 # Run tests
 
-To run tests:
+To run tests: (inside docker)
+
 go test -v ./...
 
 ## To come out of devcontainer:
 
-press F1: Dev Containers: Reopen Folder Locally
+To exit devcontainer: press F1: Dev Containers: Reopen folder locally
+
+Or devcontainer is started throught terminal, use 'exit' to come out of bash.
+Stop container if required by :
+docker stop payoutmanagementsystem_devcontainer-db-1
+docker stop payoutmanagementsystem_devcontainer-app-1
+
 
 
 # CI

--- a/README.md
+++ b/README.md
@@ -57,8 +57,8 @@ psql -h db -U $POSTGRES_USER -d $POSTGRES_DB -f payee/payee_db.sql
 
 It will prompt for password. Give your postgres password. (or refer to .env)
 
-If 'command not found: psql' : run : apt-get update
-                                     apt-get install -y postgresql-client
+If 'command not found: psql' : run : sudo apt-get update
+                                     sudo apt-get install -y postgresql-client
 
 ## 3. Data Access Object
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # PayoutManagementSystem
 
-
 This project is about the payout management system built using golang.
 
 # Project Setup
@@ -14,6 +13,7 @@ Clone this repo: <a href = "https://github.com/Swarathmica-infraspec/payout-mana
 GO-VERSION: 1.25.0
 
 The project contains payoutmanagementsystem/ <br>
+
 - .github/workflows/payoutManagementSystem.yml <br>
 - payee/
   - payee.go <br>
@@ -21,12 +21,13 @@ The project contains payoutmanagementsystem/ <br>
   - payee_db.sql <br>
   - payeeDAO.go <br>
   - payeeDAO_test.go <br>
+  - payeeAPI.go <br>
+  - payeeApi_test.go <br>
 - go.mod <br>
 - go.sum <br>
 - README.md <br>
 
 NOTE: Only email ids with .com are supported.
-
 
 # Database Setup
 
@@ -58,9 +59,39 @@ It will prompt for password. Give your postgres password. (or refer to .env)
 
 If 'command not found: psql' : run : apt-get install -y postgresql-client
 
-# Data Access Object
+## 3. Data Access Object
 
 payeeDAO contains database query for payee and payeeDAO_test contains relevant tests
+
+## 4. HTTP API Usage
+
+since postgres is run from docker, 
+
+docker exec -it devcontainer-app-1 bash
+
+cd /workspaces/payoutManagementSystem
+
+then run: go run main.go #entry point
+
+payeeApi.go has the code for API while payeeAPI_test.go has test code
+
+NOTE: Supports only POST request
+
+1. POST request 
+curl -X POST http://localhost:8080/payees \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name":"Abc",
+    "code":"123",
+    "account_number":1234567890,
+    "ifsc":"CBIN0123456",
+    "bank":"CBI",
+    "email":"abc@example.com",
+    "mobile":9876543210,
+    "category":"Employee"
+  }'
+
+expected response: {'id':1}
 
 # Run tests
 
@@ -69,21 +100,41 @@ To run tests: (inside docker)
 go test -v ./...
 
 
-NOTE: this project is still under development and hence does not have HTTP API now.
 
-# NOTE:
+## To come out of devcontainer:
 
-To exit devcontainer: press F1: Dev Containers: Reopen folder locally
-
-Or devcontainer is started throught terminal, use 'exit' to come out of bash.
-Stop container if required by :
-docker stop payoutmanagementsystem_devcontainer-db-1
-docker stop payoutmanagementsystem_devcontainer-app-1
+press F1: Dev Containers: Reopen Folder Locally
 
 Or devcontainer is started throught terminal, use 'exit' to come out of bash.
 Stop container if required by :
 docker stop payoutmanagementsystem_devcontainer-db-1
 docker stop payoutmanagementsystem_devcontainer-app-1
+
+NOTE: Only email ids with .com are supported.
+
+
+
+# Database Setup
+
+We use PostgreSQL running inside Docker for persistant storage.
+
+## Start Postgres with Docker Compose
+
+From the project root, open VS Code. Press F1: Dev Containers: Reopen in Dev Container
+
+This will start PostgreSQL in a container.
+
+
+# Run tests
+
+To run tests:
+go test -v ./...
+
+
+
+## To come out of devcontainer:
+
+press F1: Dev Containers: Reopen Folder Locally
 
 
 # CI

--- a/README.md
+++ b/README.md
@@ -53,11 +53,12 @@ devcontainer exec --workspace-folder . bash
 ## 2. Create Payees Table
 
 Run the below command for the first time (or if db does not exist):
-psql -h db -U $POSTGRES_USER -d $POSTGRES_DB -f payee_db.sql
+psql -h db -U $POSTGRES_USER -d $POSTGRES_DB -f payee/payee_db.sql
 
 It will prompt for password. Give your postgres password. (or refer to .env)
 
-If 'command not found: psql' : run : apt-get install -y postgresql-client
+If 'command not found: psql' : run : apt-get update
+                                     apt-get install -y postgresql-client
 
 ## 3. Data Access Object
 
@@ -75,7 +76,7 @@ then run: go run main.go #entry point
 
 payeeApi.go has the code for API while payeeAPI_test.go has test code
 
-NOTE: Supports only POST request
+
 
 1. POST request 
 curl -X POST http://localhost:8080/payees \
@@ -93,44 +94,11 @@ curl -X POST http://localhost:8080/payees \
 
 expected response: {'id':1}
 
-# Run tests
-
-To run tests: (inside docker)
-
-go test -v ./...
-
-
-
-## To come out of devcontainer:
-
-press F1: Dev Containers: Reopen Folder Locally
-
-Or devcontainer is started throught terminal, use 'exit' to come out of bash.
-Stop container if required by :
-docker stop payoutmanagementsystem_devcontainer-db-1
-docker stop payoutmanagementsystem_devcontainer-app-1
-
-NOTE: Only email ids with .com are supported.
-
-
-
-# Database Setup
-
-We use PostgreSQL running inside Docker for persistant storage.
-
-## Start Postgres with Docker Compose
-
-From the project root, open VS Code. Press F1: Dev Containers: Reopen in Dev Container
-
-This will start PostgreSQL in a container.
-
 
 # Run tests
 
 To run tests:
 go test -v ./...
-
-
 
 ## To come out of devcontainer:
 

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,4 @@ module payoutmanagementsystem
 
 go 1.25.0
 
-require (
-	github.com/lib/pq v1.10.9
-)
+require github.com/lib/pq v1.10.9

--- a/main.go
+++ b/main.go
@@ -1,0 +1,16 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	payee "payoutmanagementsystem/payee"
+)
+
+func main() {
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /payee", payee.PayeePostAPI)
+	fmt.Println("Server starting on :8080")
+
+	log.Fatal(http.ListenAndServe(":8080", mux))
+}

--- a/main.go
+++ b/main.go
@@ -9,7 +9,7 @@ import (
 
 func main() {
 	mux := http.NewServeMux()
-	mux.HandleFunc("POST /payee", payee.PayeePostAPI)
+	mux.HandleFunc("POST /payees", payee.PayeePostAPI)
 	fmt.Println("Server starting on :8080")
 
 	log.Fatal(http.ListenAndServe(":8080", mux))

--- a/main.go
+++ b/main.go
@@ -4,13 +4,12 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+
 	payee "payoutmanagementsystem/payee"
 )
 
 func main() {
-	mux := http.NewServeMux()
-	mux.HandleFunc("POST /payees", payee.PayeePostAPI)
+	mux := payee.SetupRouter()
 	fmt.Println("Server starting on :8080")
-
 	log.Fatal(http.ListenAndServe(":8080", mux))
 }

--- a/payee/payeeApi.go
+++ b/payee/payeeApi.go
@@ -66,9 +66,13 @@ func PayeePostAPI(w http.ResponseWriter, r *http.Request) {
 		fmt.Println(err)
 		fmt.Println("Insertion failed")
 		w.WriteHeader(http.StatusConflict)
-		json.NewEncoder(w).Encode(map[string]string{
+		if err := json.NewEncoder(w).Encode(map[string]string{
 			"error": "Payee cannot be created with duplicate values",
-		})
+		}); err != nil {
+			log.Printf("Failed to encode JSON response: %v", err)
+			return
+		}
+
 		return
 	}
 

--- a/payee/payeeApi.go
+++ b/payee/payeeApi.go
@@ -77,8 +77,6 @@ func PayeePostAPI(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	fmt.Printf("Received POST request with message")
-
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusCreated)
 	if err := json.NewEncoder(w).Encode(map[string]any{

--- a/payee/payeeApi.go
+++ b/payee/payeeApi.go
@@ -15,10 +15,7 @@ import (
 
 func PayeePostAPI(w http.ResponseWriter, r *http.Request) {
 
-	dsn := os.Getenv("DATABASE_URL")
-	if dsn == "" {
-		dsn = "postgres://postgres:postgres@db:5432/postgres?sslmode=disable"
-	}
+	dsn := os.Getenv("TEST_DATABASE_URL")
 
 	db, err := sql.Open("postgres", dsn)
 	if err != nil {

--- a/payee/payeeApi.go
+++ b/payee/payeeApi.go
@@ -20,7 +20,12 @@ func PayeePostAPI(w http.ResponseWriter, r *http.Request) {
 	db, err := sql.Open("postgres", dsn)
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
-		json.NewEncoder(w).Encode(map[string]string{"error": "Failed to connect to database"})
+		if err := json.NewEncoder(w).Encode(map[string]string{
+			"error": "Failed to connect to database",
+		}); err != nil {
+			log.Printf("failed to write JSON response: %v", err)
+		}
+
 		return
 	}
 

--- a/payee/payeeApi.go
+++ b/payee/payeeApi.go
@@ -86,3 +86,9 @@ func PayeePostAPI(w http.ResponseWriter, r *http.Request) {
 	}
 
 }
+
+func SetupRouter() *http.ServeMux {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/payees", PayeePostAPI)
+	return mux
+}

--- a/payee/payeeApi.go
+++ b/payee/payeeApi.go
@@ -42,11 +42,6 @@ func PayeePostAPI(w http.ResponseWriter, r *http.Request) {
 
 	var data req
 
-	if r.Method != http.MethodPost {
-		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
-		return
-	}
-
 	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		http.Error(w, "Error reading request body", http.StatusInternalServerError)

--- a/payee/payeeApi.go
+++ b/payee/payeeApi.go
@@ -1,0 +1,91 @@
+package payee
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+
+	_ "github.com/lib/pq"
+)
+
+func PayeePostAPI(w http.ResponseWriter, r *http.Request) {
+
+	dsn := os.Getenv("DATABASE_URL")
+	if dsn == "" {
+		dsn = "postgres://postgres:postgres@db:5432/postgres?sslmode=disable"
+	}
+
+	db, err := sql.Open("postgres", dsn)
+	if err != nil {
+		panic(err)
+	}
+	defer func() {
+		if err := db.Close(); err != nil {
+			log.Printf("failed to close db: %v", err)
+		}
+	}()
+
+	store := PayeeDB(db)
+
+	type req struct {
+		Name     string `json:"name"`
+		Code     string `json:"code"`
+		AccNo    int    `json:"account_number"`
+		IFSC     string `json:"ifsc"`
+		Bank     string `json:"bank"`
+		Email    string `json:"email"`
+		Mobile   int    `json:"mobile"`
+		Category string `json:"category"`
+	}
+
+	var data req
+
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		http.Error(w, "Error reading request body", http.StatusInternalServerError)
+		return
+	}
+
+	err = json.Unmarshal(body, &data)
+	if err != nil {
+		http.Error(w, "Error unmarshaling JSON", http.StatusBadRequest)
+		return
+	}
+
+	p, err := NewPayee(data.Name, data.Code, data.AccNo, data.IFSC, data.Bank, data.Email, data.Mobile, data.Category)
+	if err != nil {
+		fmt.Println("Structure creation failed")
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	_, err = store.Insert(context.Background(), p)
+	if err != nil {
+		fmt.Println(err)
+		fmt.Println("Insertion failed")
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	fmt.Printf("Received POST request with message")
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusCreated)
+	if err := json.NewEncoder(w).Encode(map[string]any{
+		"id": 1,
+	}); err != nil {
+		http.Error(w, "failed to encode response", http.StatusInternalServerError)
+		return
+	}
+
+}

--- a/payee/payeeApi.go
+++ b/payee/payeeApi.go
@@ -70,7 +70,10 @@ func PayeePostAPI(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		fmt.Println(err)
 		fmt.Println("Insertion failed")
-		w.WriteHeader(http.StatusInternalServerError)
+		w.WriteHeader(http.StatusConflict)
+		json.NewEncoder(w).Encode(map[string]string{
+			"error": "Payee cannot be created with duplicate values",
+		})
 		return
 	}
 

--- a/payee/payeeApi_test.go
+++ b/payee/payeeApi_test.go
@@ -71,8 +71,23 @@ func TestPayeePostAPISuccess(t *testing.T) {
 
 	mux.ServeHTTP(w, req)
 
+	type Response struct {
+		ID int `json:"id"`
+	}
+
+	var resp Response
+	err := json.Unmarshal([]byte(w.Body.Bytes()), &resp)
+	if err != nil {
+		t.Fatal("Error unmarshaling JSON:", err)
+		return
+	}
+
 	if w.Code != http.StatusCreated {
 		t.Fatalf("expected status %d, got %d, body=%s", http.StatusCreated, w.Code, w.Body.String())
+	}
+
+	if resp.ID != 1 {
+		t.Fatalf("The response body should be {\"id\":1}")
 	}
 }
 

--- a/payee/payeeApi_test.go
+++ b/payee/payeeApi_test.go
@@ -45,8 +45,7 @@ func setupMux(t *testing.T) *http.ServeMux {
 		t.Fatalf("failed to clean DB: %v", err)
 	}
 
-	mux := http.NewServeMux()
-	mux.HandleFunc("/payees", PayeePostAPI)
+	mux := SetupRouter()
 
 	return mux
 }

--- a/payee/payeeApi_test.go
+++ b/payee/payeeApi_test.go
@@ -102,4 +102,12 @@ func TestPayeePostAPIInvalidJSON(t *testing.T) {
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("expected status %d, got %d, body=%s", http.StatusBadRequest, w.Code, w.Body.String())
 	}
+
+	resp := w.Body.String()
+	expected := "Error unmarshaling JSON\n"
+
+	if resp != expected {
+		t.Fatalf("expected body %q, got %q", expected, resp)
+	}
+
 }

--- a/payee/payeeApi_test.go
+++ b/payee/payeeApi_test.go
@@ -84,7 +84,10 @@ func TestPayeePostAPISuccess(t *testing.T) {
 	if w.Code != http.StatusCreated {
 		t.Fatalf("expected status %d, got %d, body=%s", http.StatusCreated, w.Code, w.Body.String())
 	}
-
+	expected := `{"id":1}` + "\n"
+	if w.Body.String() != expected {
+		t.Fatalf("expected body %q, got %q", expected, w.Body.String())
+	}
 	if resp.ID != 1 {
 		t.Fatalf("The response body should be {\"id\":1}")
 	}

--- a/payee/payeeApi_test.go
+++ b/payee/payeeApi_test.go
@@ -104,7 +104,7 @@ func TestPayeePostAPIInvalidJSON(t *testing.T) {
 	}
 
 	resp := w.Body.String()
-	expected := "Error unmarshaling JSON\n"
+	expected := `{"error":"Error unmarshaling JSON"}` + "\n"
 
 	if resp != expected {
 		t.Fatalf("expected body %q, got %q", expected, resp)

--- a/payee/payeeApi_test.go
+++ b/payee/payeeApi_test.go
@@ -1,0 +1,53 @@
+package payee
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func setupMux() *http.ServeMux {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/payees", PayeePostAPI)
+	return mux
+}
+
+func TestPayeePostAPISuccess(t *testing.T) {
+	mux := setupMux()
+
+	payload := map[string]interface{}{
+		"name":           "Abdc",
+		"code":           "1263",
+		"account_number": 1234767891,
+		"ifsc":           "CBIN0123456",
+		"bank":           "CBI",
+		"email":          "abdc@example.com",
+		"mobile":         9876543290,
+		"category":       "Employee",
+	}
+	body, _ := json.Marshal(payload)
+
+	req := httptest.NewRequest(http.MethodPost, "/payees", bytes.NewBuffer(body))
+	w := httptest.NewRecorder()
+
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected status %d, got %d, body=%s", http.StatusCreated, w.Code, w.Body.String())
+	}
+}
+
+func TestPayeePostAPIInvalidJSON(t *testing.T) {
+	mux := setupMux()
+
+	req := httptest.NewRequest(http.MethodPost, "/payees", bytes.NewBufferString("{bad json}"))
+	w := httptest.NewRecorder()
+
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected status %d, got %d, body=%s", http.StatusBadRequest, w.Code, w.Body.String())
+	}
+}

--- a/payee/payeeApi_test.go
+++ b/payee/payeeApi_test.go
@@ -88,9 +88,7 @@ func TestPayeePostAPISuccess(t *testing.T) {
 	if w.Body.String() != expected {
 		t.Fatalf("expected body %q, got %q", expected, w.Body.String())
 	}
-	if resp.ID != 1 {
-		t.Fatalf("The response body should be {\"id\":1}")
-	}
+
 }
 
 func TestPayeePostAPIInvalidJSON(t *testing.T) {

--- a/payee/payeeDAO_test.go
+++ b/payee/payeeDAO_test.go
@@ -73,3 +73,55 @@ func TestInsertAndGetPayee(t *testing.T) {
 		t.Errorf("expected beneficiary code: %s, got: %s", p.payeeCategory, got.payeeCategory)
 	}
 }
+
+func TestInsertPayee(t *testing.T) {
+	db := setupTestDB(t)
+	store := PayeeDB(db)
+	ctx := context.Background()
+
+	p, _ := NewPayee("Abc", "136", 1234567890123456, "CBIN0123459", "CBI", "abc@gmail.com", 9123456780, "Employee")
+
+	id, err := store.Insert(ctx, p)
+	if err != nil {
+		t.Fatalf("failed to insert payee: %v", err)
+	}
+	defer db.Exec("DELETE FROM payees WHERE id = $1", id)
+
+	var code, name, bank, ifsc, email, category string
+	var accNo int
+	var mobile int
+	err = db.QueryRow(`
+		SELECT beneficiary_code, beneficiary_name, account_number, ifsc_code, bank_name, email, mobile, payee_category
+		FROM payees WHERE id = $1`, id).
+		Scan(&code, &name, &accNo, &ifsc, &bank, &email, &mobile, &category)
+	if err != nil {
+		t.Fatalf("failed to query payee: %v", err)
+	}
+
+	if code != p.beneficiaryCode {
+		t.Errorf("expected %+v, got %+v", code, p.beneficiaryCode)
+	}
+
+	if name != p.beneficiaryName {
+		t.Errorf("expected %+v, got %+v", name, p.beneficiaryName)
+	}
+	if accNo != p.accNo {
+		t.Errorf("expected %+v, got %+v", accNo, p.accNo)
+	}
+
+	if ifsc != p.ifsc {
+		t.Errorf("expected %+v, got %+v", ifsc, p.ifsc)
+	}
+	if bank != p.bankName {
+		t.Errorf("expected %+v, got %+v", bank, p.bankName)
+	}
+	if email != p.email {
+		t.Errorf("expected %+v, got %+v", email, p.email)
+	}
+	if mobile != p.mobile {
+		t.Errorf("expected %+v, got %+v", mobile, p.mobile)
+	}
+	if category != p.payeeCategory {
+		t.Errorf("expected %+v, got %+v", mobile, p.mobile)
+	}
+}

--- a/payee/payeeDAO_test.go
+++ b/payee/payeeDAO_test.go
@@ -33,7 +33,11 @@ func TestInsertPayee(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to insert payee: %v", err)
 	}
-	defer db.Exec("DELETE FROM payees WHERE id = $1", id)
+	defer func() {
+		if _, err := db.Exec("DELETE FROM payees WHERE id = $1", id); err != nil {
+			t.Logf("failed to clear payee: %v", err)
+		}
+	}()
 
 	var code, name, bank, ifsc, email, category string
 	var accNo int
@@ -87,7 +91,11 @@ func TestGetPayeeByID(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to insert fixture payee: %v", err)
 	}
-	defer db.Exec("DELETE FROM payees WHERE id = $1", id)
+	defer func() {
+		if _, err := db.Exec("DELETE FROM payees WHERE id = $1", id); err != nil {
+			t.Logf("failed to clear payee: %v", err)
+		}
+	}()
 
 	got, err := store.GetByID(ctx, id)
 	if err != nil {

--- a/payee/payeeDAO_test.go
+++ b/payee/payeeDAO_test.go
@@ -24,11 +24,6 @@ func setupTestDB(t *testing.T) *sql.DB {
 
 func TestInsertAndGetPayee(t *testing.T) {
 	db := setupTestDB(t)
-	defer func() {
-		if err := db.Close(); err != nil {
-			t.Errorf("failed to close DB connection: %v", err)
-		}
-	}()
 	store := PayeeDB(db)
 	ctx := context.Background()
 

--- a/payee/payeeDAO_test.go
+++ b/payee/payeeDAO_test.go
@@ -98,11 +98,40 @@ func TestGetPayeeByID(t *testing.T) {
 	}()
 
 	got, err := store.GetByID(ctx, id)
+	name := "Abc"
+	code := "136"
+	accNo := 1234567890123456
+	ifsc := "CBIN0123459"
+	bank := "CBI"
+	email := "abc@gmail.com"
+	mobile := 9123456780
+	category := "Employee"
 	if err != nil {
 		t.Fatalf("failed to fetch payee: %v", err)
 	}
 
-	if got.beneficiaryName != "Abc" {
-		t.Errorf("expected name Abc, got %s", got.beneficiaryName)
+	if got.beneficiaryName != name {
+		t.Errorf("expected name %s, got %s", name, got.beneficiaryName)
+	}
+	if got.beneficiaryCode != code {
+		t.Errorf("expected  code %s, got %s", code, got.beneficiaryCode)
+	}
+	if got.accNo != accNo {
+		t.Errorf("expected accNo %d, got %d", accNo, got.accNo)
+	}
+	if got.ifsc != ifsc {
+		t.Errorf("expected ifsc %s, got %s", ifsc, got.ifsc)
+	}
+	if got.bankName != bank {
+		t.Errorf("expected bank %s, got %s", bank, got.bankName)
+	}
+	if got.email != email {
+		t.Errorf("expected email %s, got %s", email, got.email)
+	}
+	if got.mobile != mobile {
+		t.Errorf("expected mobile %d, got %d", mobile, got.mobile)
+	}
+	if got.payeeCategory != category {
+		t.Errorf("expected category %s, got %s", category, got.payeeCategory)
 	}
 }

--- a/payee/payeeDAO_test.go
+++ b/payee/payeeDAO_test.go
@@ -22,58 +22,6 @@ func setupTestDB(t *testing.T) *sql.DB {
 	return db
 }
 
-func TestInsertAndGetPayee(t *testing.T) {
-	db := setupTestDB(t)
-	store := PayeeDB(db)
-	ctx := context.Background()
-
-	p, err := NewPayee("Abc", "136", 1234567890123456, "CBIN0123459", "CBI", "abc@gmail.com", 9123456780, "Employee")
-	if err != nil {
-		t.Fatalf("validation failed: %v", err)
-	}
-
-	id, err := store.Insert(ctx, p)
-	if err != nil {
-		t.Fatalf("failed to insert payee: %v", err)
-	}
-
-	defer func() {
-		if _, err := db.Exec("DELETE FROM payees WHERE id = $1", id); err != nil {
-			t.Errorf("warning: failed to clean up payee id %d: %v", id, err)
-		}
-	}()
-
-	got, err := store.GetByID(ctx, id)
-	if err != nil {
-		t.Fatalf("failed to fetch payee: %v", err)
-	}
-
-	if got.beneficiaryCode != p.beneficiaryCode {
-		t.Errorf("expected beneficiary code: %s, got: %s", p.beneficiaryCode, got.beneficiaryCode)
-	}
-	if got.beneficiaryName != p.beneficiaryName {
-		t.Errorf("expected beneficiary name: %s, got: %s", p.beneficiaryName, got.beneficiaryName)
-	}
-	if got.accNo != p.accNo {
-		t.Errorf("expected accNo: %d, got: %d", p.accNo, got.accNo)
-	}
-	if got.ifsc != p.ifsc {
-		t.Errorf("expected IFSC code: %s, got: %s", p.ifsc, got.ifsc)
-	}
-	if got.bankName != p.bankName {
-		t.Errorf("expected bank name: %s, got: %s", p.bankName, got.bankName)
-	}
-	if got.email != p.email {
-		t.Errorf("expected email: %s, got: %s", p.email, got.email)
-	}
-	if got.mobile != p.mobile {
-		t.Errorf("expected mobile: %d, got: %d", p.mobile, got.mobile)
-	}
-	if got.payeeCategory != p.payeeCategory {
-		t.Errorf("expected beneficiary code: %s, got: %s", p.payeeCategory, got.payeeCategory)
-	}
-}
-
 func TestInsertPayee(t *testing.T) {
 	db := setupTestDB(t)
 	store := PayeeDB(db)

--- a/payee/payee_test.go
+++ b/payee/payee_test.go
@@ -45,6 +45,7 @@ func TestInvalidPayee(t *testing.T) {
 }
 
 func TestValidPayee(t *testing.T) {
+
 	_, err := NewPayee("abc", "123", 1234567890, "CBIN0123456", "cbi", "abc@gmail.com", 9876543210, "Employee")
 	if err != nil {
 		t.Fatalf("payee should be created but got error: %v", err)


### PR DESCRIPTION
Implemented HTTP API endpoint for creating a new payee (POST /payee).
Added Postgres integration, fixing workflow for inserting records.
Updated Docker Compose to run the app alongside the database, exposing port 8080.
Improved README with setup instructions and usage notes.