### PR TITLE
Add test for unique constraints of payee 

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,12 @@ expected response: {'id':1}
 
 # Run tests
 
+## Unique Constraints
+
+The payees table enforces unique constraints for the column beneficiary_code, account_number, email and mobile to maintain data integrity.
+
+If an insert violates these constraints, the database will return a duplicate key error.
+
 To run tests: (inside docker)
 
 go test -v ./...

--- a/payee/payeeApi.go
+++ b/payee/payeeApi.go
@@ -24,14 +24,18 @@ func PayeePostAPI(store PayeeRepository) http.HandlerFunc {
 		w.Header().Set("Content-Type", "application/json")
 		if err := json.NewDecoder(r.Body).Decode(&data); err != nil {
 			w.WriteHeader(http.StatusBadRequest)
-			_ = json.NewEncoder(w).Encode(map[string]string{"error": "Invalid JSON body"})
+			if err := json.NewEncoder(w).Encode(map[string]string{"error": "Invalid JSON body"}); err != nil {
+				log.Printf("Failed to encode response (invalid JSON body): %v", err)
+			}
 			return
 		}
 
 		p, err := NewPayee(data.Name, data.Code, data.AccNo, data.IFSC, data.Bank, data.Email, data.Mobile, data.Category)
 		if err != nil {
 			w.WriteHeader(http.StatusBadRequest)
-			_ = json.NewEncoder(w).Encode(map[string]string{"error": "Invalid payee data"})
+			if err := json.NewEncoder(w).Encode(map[string]string{"error": "Invalid payee data"}); err != nil {
+				log.Printf("Failed to encode response (invalid payee data): %v", err)
+			}
 			return
 		}
 
@@ -61,15 +65,21 @@ func PayeePostAPI(store PayeeRepository) http.HandlerFunc {
 
 			w.WriteHeader(status)
 			if status == http.StatusConflict {
-				_ = json.NewEncoder(w).Encode(map[string]string{"error": "Payee with the same " + errMsg + " already exists"})
+				if err := json.NewEncoder(w).Encode(map[string]string{"error": "Payee with the same " + errMsg + " already exists"}); err != nil {
+					log.Printf("Failed to encode response (column value repetition): %v", err)
+				}
 			} else {
-				_ = json.NewEncoder(w).Encode(map[string]string{"error": "Something went wrong"})
+				if err := json.NewEncoder(w).Encode(map[string]string{"error": "Something went wrong"}); err != nil {
+					log.Printf("Failed to encode response (conflict due to server error): %v", err)
+				}
 				log.Printf("Internal error: %v", err)
 			}
 			return
 		}
 		w.WriteHeader(http.StatusCreated)
-		_ = json.NewEncoder(w).Encode(map[string]any{"id": id})
+		if err := json.NewEncoder(w).Encode(map[string]any{"id": id}); err != nil {
+			log.Printf("Failed to encode response: %v", err)
+		}
 	}
 }
 

--- a/payee/payeeApi.go
+++ b/payee/payeeApi.go
@@ -38,11 +38,31 @@ func PayeePostAPI(store PayeeRepository) http.HandlerFunc {
 
 		id, err := store.Insert(context.Background(), p)
 		if err != nil {
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusConflict)
-			_ = json.NewEncoder(w).Encode(map[string]string{"error": "Payee already exists"})
-			return
-		}
+    w.Header().Set("Content-Type", "application/json")
+
+    var errMsg string
+    switch err {
+    case ErrDuplicateCode:
+        w.WriteHeader(http.StatusConflict)
+        errMsg = "duplicate code"
+    case ErrDuplicateAccount:
+        w.WriteHeader(http.StatusConflict)
+        errMsg = "duplicate account number"
+    case ErrDuplicateEmail:
+        w.WriteHeader(http.StatusConflict)
+        errMsg = "duplicate email"
+    case ErrDuplicateMobile:
+        w.WriteHeader(http.StatusConflict)
+        errMsg = "duplicate mobile"
+    default:
+        w.WriteHeader(http.StatusInternalServerError)
+        errMsg = "internal server error"
+    }
+
+    _ = json.NewEncoder(w).Encode(map[string]string{"error": "Insertion failed: "+errMsg})
+    return
+}
+
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)

--- a/payee/payeeApi.go
+++ b/payee/payeeApi.go
@@ -43,7 +43,7 @@ func PayeePostAPI(store PayeeRepository) http.HandlerFunc {
 			switch err {
 			case ErrDuplicateCode:
 				w.WriteHeader(http.StatusConflict)
-				errMsg = "code"
+				errMsg = "beneficiary code"
 			case ErrDuplicateAccount:
 				w.WriteHeader(http.StatusConflict)
 				errMsg = "account number"

--- a/payee/payeeApi.go
+++ b/payee/payeeApi.go
@@ -44,22 +44,22 @@ func PayeePostAPI(store PayeeRepository) http.HandlerFunc {
     switch err {
     case ErrDuplicateCode:
         w.WriteHeader(http.StatusConflict)
-        errMsg = "duplicate code"
+        errMsg = "code"
     case ErrDuplicateAccount:
         w.WriteHeader(http.StatusConflict)
-        errMsg = "duplicate account number"
+        errMsg = "account number"
     case ErrDuplicateEmail:
         w.WriteHeader(http.StatusConflict)
-        errMsg = "duplicate email"
+        errMsg = "email"
     case ErrDuplicateMobile:
         w.WriteHeader(http.StatusConflict)
-        errMsg = "duplicate mobile"
+        errMsg = "mobile"
     default:
         w.WriteHeader(http.StatusInternalServerError)
         errMsg = "internal server error"
     }
 
-    _ = json.NewEncoder(w).Encode(map[string]string{"error": "Insertion failed: "+errMsg})
+    _ = json.NewEncoder(w).Encode(map[string]string{"error": "Payee already exists with the same: "+errMsg})
     return
 }
 

--- a/payee/payeeApi.go
+++ b/payee/payeeApi.go
@@ -25,6 +25,13 @@ func respondError(w http.ResponseWriter, status int, message string) {
 	}
 }
 
+func respondSuccess(w http.ResponseWriter, status int, data any) {
+	w.WriteHeader(status)
+	if err := json.NewEncoder(w).Encode(data); err != nil {
+		log.Printf("Failed to encode success response: %v", err)
+	}
+}
+
 func PayeePostAPI(store PayeeRepository) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		var data PayeeRequest
@@ -78,10 +85,8 @@ func PayeePostAPI(store PayeeRepository) http.HandlerFunc {
 			}
 			return
 		}
-		w.WriteHeader(http.StatusCreated)
-		if err := json.NewEncoder(w).Encode(map[string]any{"id": id}); err != nil {
-			log.Printf("Failed to encode response: %v", err)
-		}
+
+		respondSuccess(w, http.StatusCreated, map[string]any{"id": id})
 	}
 }
 

--- a/payee/payeeApi.go
+++ b/payee/payeeApi.go
@@ -61,7 +61,7 @@ func PayeePostAPI(store PayeeRepository) http.HandlerFunc {
 
 			w.WriteHeader(status)
 			if status == http.StatusConflict {
-				_ = json.NewEncoder(w).Encode(map[string]string{"error": "Payee already exists with the same: " + errMsg})
+				_ = json.NewEncoder(w).Encode(map[string]string{"error": "Payee with the same " + errMsg + " already exists"})
 			} else {
 				_ = json.NewEncoder(w).Encode(map[string]string{"error": "Something went wrong"})
 				log.Printf("Internal error: %v", err)

--- a/payee/payeeApi.go
+++ b/payee/payeeApi.go
@@ -3,6 +3,7 @@ package payee
 import (
 	"context"
 	"encoding/json"
+	"log"
 	"net/http"
 )
 
@@ -62,7 +63,8 @@ func PayeePostAPI(store PayeeRepository) http.HandlerFunc {
 			if status == http.StatusConflict {
 				_ = json.NewEncoder(w).Encode(map[string]string{"error": "Payee already exists with the same: " + errMsg})
 			} else {
-				_ = json.NewEncoder(w).Encode(map[string]string{"error": errMsg})
+				_ = json.NewEncoder(w).Encode(map[string]string{"error": "Something went wrong"})
+				log.Printf("Internal error: %v", err)
 			}
 			return
 		}

--- a/payee/payeeApi.go
+++ b/payee/payeeApi.go
@@ -19,7 +19,6 @@ type PayeeRequest struct {
 
 func PayeePostAPI(store PayeeRepository) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-
 		var data PayeeRequest
 		if err := json.NewDecoder(r.Body).Decode(&data); err != nil {
 			w.Header().Set("Content-Type", "application/json")
@@ -38,31 +37,30 @@ func PayeePostAPI(store PayeeRepository) http.HandlerFunc {
 
 		id, err := store.Insert(context.Background(), p)
 		if err != nil {
-    w.Header().Set("Content-Type", "application/json")
+			w.Header().Set("Content-Type", "application/json")
 
-    var errMsg string
-    switch err {
-    case ErrDuplicateCode:
-        w.WriteHeader(http.StatusConflict)
-        errMsg = "code"
-    case ErrDuplicateAccount:
-        w.WriteHeader(http.StatusConflict)
-        errMsg = "account number"
-    case ErrDuplicateEmail:
-        w.WriteHeader(http.StatusConflict)
-        errMsg = "email"
-    case ErrDuplicateMobile:
-        w.WriteHeader(http.StatusConflict)
-        errMsg = "mobile"
-    default:
-        w.WriteHeader(http.StatusInternalServerError)
-        errMsg = "internal server error"
-    }
+			var errMsg string
+			switch err {
+			case ErrDuplicateCode:
+				w.WriteHeader(http.StatusConflict)
+				errMsg = "code"
+			case ErrDuplicateAccount:
+				w.WriteHeader(http.StatusConflict)
+				errMsg = "account number"
+			case ErrDuplicateEmail:
+				w.WriteHeader(http.StatusConflict)
+				errMsg = "email"
+			case ErrDuplicateMobile:
+				w.WriteHeader(http.StatusConflict)
+				errMsg = "mobile"
+			default:
+				w.WriteHeader(http.StatusInternalServerError)
+				errMsg = "internal server error"
+			}
 
-    _ = json.NewEncoder(w).Encode(map[string]string{"error": "Payee already exists with the same: "+errMsg})
-    return
-}
-
+			_ = json.NewEncoder(w).Encode(map[string]string{"error": "Payee already exists with the same: " + errMsg})
+			return
+		}
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)

--- a/payee/payeeApi.go
+++ b/payee/payeeApi.go
@@ -38,28 +38,34 @@ func PayeePostAPI(store PayeeRepository) http.HandlerFunc {
 		if err != nil {
 
 			var errMsg string
+			var status int
+
 			switch err {
 			case ErrDuplicateCode:
-				w.WriteHeader(http.StatusConflict)
 				errMsg = "beneficiary code"
+				status = http.StatusConflict
 			case ErrDuplicateAccount:
-				w.WriteHeader(http.StatusConflict)
 				errMsg = "account number"
+				status = http.StatusConflict
 			case ErrDuplicateEmail:
-				w.WriteHeader(http.StatusConflict)
 				errMsg = "email"
+				status = http.StatusConflict
 			case ErrDuplicateMobile:
-				w.WriteHeader(http.StatusConflict)
 				errMsg = "mobile"
+				status = http.StatusConflict
 			default:
-				w.WriteHeader(http.StatusInternalServerError)
 				errMsg = "internal server error"
+				status = http.StatusInternalServerError
 			}
 
-			_ = json.NewEncoder(w).Encode(map[string]string{"error": "Payee already exists with the same: " + errMsg})
+			w.WriteHeader(status)
+			if status == http.StatusConflict {
+				_ = json.NewEncoder(w).Encode(map[string]string{"error": "Payee already exists with the same: " + errMsg})
+			} else {
+				_ = json.NewEncoder(w).Encode(map[string]string{"error": errMsg})
+			}
 			return
 		}
-
 		w.WriteHeader(http.StatusCreated)
 		_ = json.NewEncoder(w).Encode(map[string]any{"id": id})
 	}

--- a/payee/payeeApi.go
+++ b/payee/payeeApi.go
@@ -20,8 +20,8 @@ type PayeeRequest struct {
 func PayeePostAPI(store PayeeRepository) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		var data PayeeRequest
+		w.Header().Set("Content-Type", "application/json")
 		if err := json.NewDecoder(r.Body).Decode(&data); err != nil {
-			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusBadRequest)
 			_ = json.NewEncoder(w).Encode(map[string]string{"error": "Invalid JSON body"})
 			return
@@ -29,7 +29,6 @@ func PayeePostAPI(store PayeeRepository) http.HandlerFunc {
 
 		p, err := NewPayee(data.Name, data.Code, data.AccNo, data.IFSC, data.Bank, data.Email, data.Mobile, data.Category)
 		if err != nil {
-			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusBadRequest)
 			_ = json.NewEncoder(w).Encode(map[string]string{"error": "Invalid payee data"})
 			return
@@ -37,7 +36,6 @@ func PayeePostAPI(store PayeeRepository) http.HandlerFunc {
 
 		id, err := store.Insert(context.Background(), p)
 		if err != nil {
-			w.Header().Set("Content-Type", "application/json")
 
 			var errMsg string
 			switch err {
@@ -62,7 +60,6 @@ func PayeePostAPI(store PayeeRepository) http.HandlerFunc {
 			return
 		}
 
-		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
 		_ = json.NewEncoder(w).Encode(map[string]any{"id": id})
 	}

--- a/payee/payeeApi_test.go
+++ b/payee/payeeApi_test.go
@@ -136,7 +136,7 @@ func TestPayeePostAPIUniqueConstraints(t *testing.T) {
 				"category":       "Employee",
 			},
 			wantCode: http.StatusConflict,
-			wantJSON: `{"error":"Payee already exists with the same: beneficiary code"}`,
+			wantJSON: `{"error":"Payee with the same beneficiary code already exists"}`,
 		},
 		{
 			name: "duplicate account",
@@ -151,7 +151,7 @@ func TestPayeePostAPIUniqueConstraints(t *testing.T) {
 				"category":       "Employee",
 			},
 			wantCode: http.StatusConflict,
-			wantJSON: `{"error":"Payee already exists with the same: account number"}`,
+			wantJSON: `{"error":"Payee with the same account number already exists"}`,
 		},
 		{
 			name: "duplicate email",
@@ -166,7 +166,7 @@ func TestPayeePostAPIUniqueConstraints(t *testing.T) {
 				"category":       "Employee",
 			},
 			wantCode: http.StatusConflict,
-			wantJSON: `{"error":"Payee already exists with the same: email"}`,
+			wantJSON: `{"error":"Payee with the same email already exists"}`,
 		},
 		{
 			name: "duplicate mobile",
@@ -181,7 +181,7 @@ func TestPayeePostAPIUniqueConstraints(t *testing.T) {
 				"category":       "Employee",
 			},
 			wantCode: http.StatusConflict,
-			wantJSON: `{"error":"Payee already exists with the same: mobile"}`,
+			wantJSON: `{"error":"Payee with the same mobile already exists"}`,
 		},
 	}
 

--- a/payee/payeeApi_test.go
+++ b/payee/payeeApi_test.go
@@ -107,12 +107,15 @@ func TestPayeePostAPIUniqueConstraints(t *testing.T) {
 		"mobile":         9123456780,
 		"category":       "Employee",
 	}
-	body, _ := json.Marshal(original)
-
-	req1 := httptest.NewRequest(http.MethodPost, "/payees", bytes.NewBuffer(body))
-	w1 := httptest.NewRecorder()
-	mux.ServeHTTP(w1, req1)
-	assert.Equal(t, http.StatusCreated, w1.Code)
+	createPayee := func(payload map[string]interface{}) *httptest.ResponseRecorder {
+		body, _ := json.Marshal(payload)
+		req := httptest.NewRequest(http.MethodPost, "/payees", bytes.NewBuffer(body))
+		w := httptest.NewRecorder()
+		mux.ServeHTTP(w, req)
+		return w
+	}
+	w := createPayee(original)
+	assert.Equal(t, http.StatusCreated, w.Code)
 
 	tests := []struct {
 		name     string
@@ -184,11 +187,7 @@ func TestPayeePostAPIUniqueConstraints(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			body, _ := json.Marshal(tt.payload)
-			req := httptest.NewRequest(http.MethodPost, "/payees", bytes.NewBuffer(body))
-			w := httptest.NewRecorder()
-			mux.ServeHTTP(w, req)
-
+			w := createPayee(tt.payload)
 			assert.Equal(t, tt.wantCode, w.Code)
 			assert.JSONEq(t, tt.wantJSON, w.Body.String())
 		})

--- a/payee/payeeApi_test.go
+++ b/payee/payeeApi_test.go
@@ -136,7 +136,7 @@ func TestPayeePostAPIUniqueConstraints(t *testing.T) {
 				"category":       "Employee",
 			},
 			wantCode: http.StatusConflict,
-			wantJSON: `{"error":"Insertion failed: duplicate code"}`,
+			wantJSON: `{"error":"Payee already exists with the same: code"}`,
 		},
 		{
 			name: "duplicate account",
@@ -151,7 +151,7 @@ func TestPayeePostAPIUniqueConstraints(t *testing.T) {
 				"category":       "Employee",
 			},
 			wantCode: http.StatusConflict,
-			wantJSON: `{"error":"Insertion failed: duplicate account number"}`,
+			wantJSON: `{"error":"Payee already exists with the same: account number"}`,
 		},
 		{
 			name: "duplicate email",
@@ -166,7 +166,7 @@ func TestPayeePostAPIUniqueConstraints(t *testing.T) {
 				"category":       "Employee",
 			},
 			wantCode: http.StatusConflict,
-			wantJSON: `{"error":"Insertion failed: duplicate email"}`,
+			wantJSON: `{"error":"Payee already exists with the same: email"}`,
 		},
 		{
 			name: "duplicate mobile",
@@ -181,7 +181,7 @@ func TestPayeePostAPIUniqueConstraints(t *testing.T) {
 				"category":       "Employee",
 			},
 			wantCode: http.StatusConflict,
-			wantJSON: `{"error":"Insertion failed: duplicate mobile"}`,
+			wantJSON: `{"error":"Payee already exists with the same: mobile"}`,
 		},
 	}
 

--- a/payee/payeeApi_test.go
+++ b/payee/payeeApi_test.go
@@ -97,7 +97,6 @@ func TestPayeePostAPIInvalidJSON(t *testing.T) {
 func TestPayeePostAPIUniqueConstraints(t *testing.T) {
 	mux := setupMux(t)
 
-	// Original payee to create first
 	original := map[string]interface{}{
 		"name":           "Abc",
 		"code":           "136",
@@ -110,13 +109,11 @@ func TestPayeePostAPIUniqueConstraints(t *testing.T) {
 	}
 	body, _ := json.Marshal(original)
 
-	// Insert original payee
 	req1 := httptest.NewRequest(http.MethodPost, "/payees", bytes.NewBuffer(body))
 	w1 := httptest.NewRecorder()
 	mux.ServeHTTP(w1, req1)
 	assert.Equal(t, http.StatusCreated, w1.Code)
 
-	// Table-driven duplicate tests
 	tests := []struct {
 		name     string
 		payload  map[string]interface{}

--- a/payee/payeeApi_test.go
+++ b/payee/payeeApi_test.go
@@ -94,33 +94,106 @@ func TestPayeePostAPIInvalidJSON(t *testing.T) {
 	assert.JSONEq(t, expected, w.Body.String())
 
 }
-func TestPayeePostAPIDuplicate(t *testing.T) {
+func TestPayeePostAPIUniqueConstraints(t *testing.T) {
 	mux := setupMux(t)
 
-	payload := map[string]interface{}{
-		"name":           "Abdc",
-		"code":           "1262",
-		"account_number": 1234767893,
-		"ifsc":           "CBIN0123456",
+	// Original payee to create first
+	original := map[string]interface{}{
+		"name":           "Abc",
+		"code":           "136",
+		"account_number": 1234567890123456,
+		"ifsc":           "CBIN0123459",
 		"bank":           "CBI",
-		"email":          "abcd@example.com",
-		"mobile":         9876543292,
+		"email":          "abc@gmail.com",
+		"mobile":         9123456780,
 		"category":       "Employee",
 	}
-	body, _ := json.Marshal(payload)
+	body, _ := json.Marshal(original)
 
+	// Insert original payee
 	req1 := httptest.NewRequest(http.MethodPost, "/payees", bytes.NewBuffer(body))
 	w1 := httptest.NewRecorder()
 	mux.ServeHTTP(w1, req1)
 	assert.Equal(t, http.StatusCreated, w1.Code)
-	req2 := httptest.NewRequest(http.MethodPost, "/payees", bytes.NewBuffer(body))
-	w2 := httptest.NewRecorder()
-	mux.ServeHTTP(w2, req2)
 
-	assert.Equal(t, http.StatusConflict, w2.Code)
+	// Table-driven duplicate tests
+	tests := []struct {
+		name     string
+		payload  map[string]interface{}
+		wantCode int
+		wantJSON string
+	}{
+		{
+			name: "duplicate code",
+			payload: map[string]interface{}{
+				"name":           "Xyz",
+				"code":           "136",
+				"account_number": 9876543210123456,
+				"ifsc":           "CBIN0123460",
+				"bank":           "CBI",
+				"email":          "xyz@gmail.com",
+				"mobile":         9876543290,
+				"category":       "Employee",
+			},
+			wantCode: http.StatusConflict,
+			wantJSON: `{"error":"Insertion failed: duplicate code"}`,
+		},
+		{
+			name: "duplicate account",
+			payload: map[string]interface{}{
+				"name":           "Xyz",
+				"code":           "137",
+				"account_number": 1234567890123456,
+				"ifsc":           "CBIN0123460",
+				"bank":           "CBI",
+				"email":          "x@gmail.com",
+				"mobile":         9876543291,
+				"category":       "Employee",
+			},
+			wantCode: http.StatusConflict,
+			wantJSON: `{"error":"Insertion failed: duplicate account number"}`,
+		},
+		{
+			name: "duplicate email",
+			payload: map[string]interface{}{
+				"name":           "Pqr",
+				"code":           "138",
+				"account_number": 1111111111111111,
+				"ifsc":           "CBIN0123461",
+				"bank":           "CBI",
+				"email":          "abc@gmail.com",
+				"mobile":         9876543292,
+				"category":       "Employee",
+			},
+			wantCode: http.StatusConflict,
+			wantJSON: `{"error":"Insertion failed: duplicate email"}`,
+		},
+		{
+			name: "duplicate mobile",
+			payload: map[string]interface{}{
+				"name":           "Lmn",
+				"code":           "139",
+				"account_number": 2222222222222222,
+				"ifsc":           "CBIN0123462",
+				"bank":           "CBI",
+				"email":          "lmn@gmail.com",
+				"mobile":         9123456780,
+				"category":       "Employee",
+			},
+			wantCode: http.StatusConflict,
+			wantJSON: `{"error":"Insertion failed: duplicate mobile"}`,
+		},
+	}
 
-	expected := `{"error":"Payee already exists"}`
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body, _ := json.Marshal(tt.payload)
+			req := httptest.NewRequest(http.MethodPost, "/payees", bytes.NewBuffer(body))
+			w := httptest.NewRecorder()
+			mux.ServeHTTP(w, req)
 
-	assert.JSONEq(t, expected, w2.Body.String())
-
+			assert.Equal(t, tt.wantCode, w.Code)
+			assert.JSONEq(t, tt.wantJSON, w.Body.String())
+		})
+	}
 }

--- a/payee/payeeApi_test.go
+++ b/payee/payeeApi_test.go
@@ -136,7 +136,7 @@ func TestPayeePostAPIUniqueConstraints(t *testing.T) {
 				"category":       "Employee",
 			},
 			wantCode: http.StatusConflict,
-			wantJSON: `{"error":"Payee already exists with the same: code"}`,
+			wantJSON: `{"error":"Payee already exists with the same: beneficiary code"}`,
 		},
 		{
 			name: "duplicate account",

--- a/payee/payeeDAO.go
+++ b/payee/payeeDAO.go
@@ -23,7 +23,8 @@ func PayeeDB(db *sql.DB) *payeeDB {
 }
 
 var (
-	ErrDuplicateCode = errors.New("duplicate beneficiary code")
+	ErrDuplicateCode    = errors.New("duplicate beneficiary code")
+	ErrDuplicateAccount = errors.New("duplicate account number")
 )
 
 func (r *payeeDB) Insert(context context.Context, p *payee) (int, error) {
@@ -46,7 +47,8 @@ func (r *payeeDB) Insert(context context.Context, p *payee) (int, error) {
 			switch pgErr.Constraint {
 			case "payees_beneficiary_code_key":
 				return 0, ErrDuplicateCode
-
+			case "payees_account_number_key":
+				return 0, ErrDuplicateAccount
 			}
 		}
 		return 0, fmt.Errorf("insert payee: %w", err)

--- a/payee/payeeDAO.go
+++ b/payee/payeeDAO.go
@@ -25,6 +25,7 @@ func PayeeDB(db *sql.DB) *payeeDB {
 var (
 	ErrDuplicateCode    = errors.New("duplicate beneficiary code")
 	ErrDuplicateAccount = errors.New("duplicate account number")
+	ErrDuplicateEmail   = errors.New("duplicate email")
 )
 
 func (r *payeeDB) Insert(context context.Context, p *payee) (int, error) {
@@ -49,6 +50,8 @@ func (r *payeeDB) Insert(context context.Context, p *payee) (int, error) {
 				return 0, ErrDuplicateCode
 			case "payees_account_number_key":
 				return 0, ErrDuplicateAccount
+			case "payees_email_key":
+				return 0, ErrDuplicateEmail
 			}
 		}
 		return 0, fmt.Errorf("insert payee: %w", err)

--- a/payee/payeeDAO.go
+++ b/payee/payeeDAO.go
@@ -55,9 +55,11 @@ func (r *payeeDB) Insert(context context.Context, p *payee) (int, error) {
 				return 0, ErrDuplicateEmail
 			case "payees_mobile_key":
 				return 0, ErrDuplicateMobile
+			default:
+				return 0, fmt.Errorf("insert payee: %w", err)
 			}
-			return 0, fmt.Errorf("insert payee: %w", err)
 		}
+		return 0, fmt.Errorf("insert payee: %w", err) //Handling non DB errors
 	}
 	return id, nil
 }

--- a/payee/payeeDAO.go
+++ b/payee/payeeDAO.go
@@ -10,8 +10,8 @@ import (
 )
 
 type PayeeRepository interface {
-	Insert(context context.Context, p *payee) (int, error)
-	GetByID(context context.Context, id int) (*payee, error)
+	Insert(ctx context.Context, p *payee) (int, error)
+	GetByID(ctx context.Context, id int) (*payee, error)
 }
 
 type payeeDB struct {
@@ -29,12 +29,12 @@ var (
 	ErrDuplicateMobile  = errors.New("duplicate mobile")
 )
 
-func (r *payeeDB) Insert(context context.Context, p *payee) (int, error) {
+func (r *payeeDB) Insert(ctx context.Context, p *payee) (int, error) {
 	query := `
 		INSERT INTO payees (beneficiary_name, beneficiary_code, account_number,ifsc_code, bank_name, email, mobile, payee_category)
 		VALUES ($1,$2,$3,$4,$5,$6,$7,$8) RETURNING id`
 	var id int
-	err := r.db.QueryRowContext(context, query,
+	err := r.db.QueryRowContext(ctx, query,
 		p.beneficiaryName,
 		p.beneficiaryCode,
 		p.accNo,
@@ -64,12 +64,12 @@ func (r *payeeDB) Insert(context context.Context, p *payee) (int, error) {
 	return id, nil
 }
 
-func (r *payeeDB) GetByID(context context.Context, id int) (*payee, error) {
+func (r *payeeDB) GetByID(ctx context.Context, id int) (*payee, error) {
 	query := `
 		SELECT beneficiary_name, beneficiary_code, account_number,
 		       ifsc_code, bank_name, email, mobile, payee_category
 		FROM payees WHERE id=$1`
-	row := r.db.QueryRowContext(context, query, id)
+	row := r.db.QueryRowContext(ctx, query, id)
 
 	var p payee
 	err := row.Scan(

--- a/payee/payeeDAO.go
+++ b/payee/payeeDAO.go
@@ -26,6 +26,7 @@ var (
 	ErrDuplicateCode    = errors.New("duplicate beneficiary code")
 	ErrDuplicateAccount = errors.New("duplicate account number")
 	ErrDuplicateEmail   = errors.New("duplicate email")
+	ErrDuplicateMobile  = errors.New("duplicate mobile")
 )
 
 func (r *payeeDB) Insert(context context.Context, p *payee) (int, error) {
@@ -52,6 +53,8 @@ func (r *payeeDB) Insert(context context.Context, p *payee) (int, error) {
 				return 0, ErrDuplicateAccount
 			case "payees_email_key":
 				return 0, ErrDuplicateEmail
+			case "payees_mobile_key":
+				return 0, ErrDuplicateMobile
 			}
 		}
 		return 0, fmt.Errorf("insert payee: %w", err)

--- a/payee/payeeDAO.go
+++ b/payee/payeeDAO.go
@@ -56,8 +56,8 @@ func (r *payeeDB) Insert(context context.Context, p *payee) (int, error) {
 			case "payees_mobile_key":
 				return 0, ErrDuplicateMobile
 			}
+			return 0, fmt.Errorf("insert payee: %w", err)
 		}
-		return 0, fmt.Errorf("insert payee: %w", err)
 	}
 	return id, nil
 }

--- a/payee/payeeDAO_test.go
+++ b/payee/payeeDAO_test.go
@@ -75,52 +75,73 @@ func TestInsertPayeeWithDuplicateValues(t *testing.T) {
 	}()
 
 	tests := []struct {
-		name      string
-		duplicate func() *payee
-		wantErr   error
+		testName string
+		nameArg  string
+		code     string
+		accNo    int
+		ifsc     string
+		bank     string
+		email    string
+		mobile   int
+		category string
+		wantErr  error
 	}{
 		{
-			name: "duplicate beneficiary code",
-			duplicate: func() *payee {
-				p, err := NewPayee("Abc", "136", 1234567800123456, "CBIN0123459", "CBI", "abcd@gmail.com", 9127456780, "Employee")
-				require.NoError(t, err)
-				return p
-			},
-			wantErr: ErrDuplicateCode,
+			testName: "duplicate beneficiary code",
+			nameArg:  "Abc",
+			code:     "136",
+			accNo:    1234567800123456,
+			ifsc:     "CBIN0123459",
+			bank:     "CBI",
+			email:    "abcd@gmail.com",
+			mobile:   9127456780,
+			category: "Employee",
+			wantErr:  ErrDuplicateCode,
 		},
 		{
-			name: "duplicate account number",
-			duplicate: func() *payee {
-				p, err := NewPayee("Xyz", "137", 1234567890123456, "CBIN0123460", "CBI", "x@gmail.com", 9123456790, "Employee")
-				require.NoError(t, err)
-				return p
-			},
-			wantErr: ErrDuplicateAccount,
+			testName: "duplicate account number",
+			nameArg:  "Xyz",
+			code:     "137",
+			accNo:    1234567890123456,
+			ifsc:     "CBIN0123460",
+			bank:     "CBI",
+			email:    "x@gmail.com",
+			mobile:   9123456790,
+			category: "Employee",
+			wantErr:  ErrDuplicateAccount,
 		},
 		{
-			name: "duplicate email",
-			duplicate: func() *payee {
-				p, err := NewPayee("Pqr", "138", 1234567890123450, "CBIN0123461", "CBI", "abc@gmail.com", 9123456800, "Employee")
-				require.NoError(t, err)
-				return p
-			},
-			wantErr: ErrDuplicateEmail,
+			testName: "duplicate email",
+			nameArg:  "Pqr",
+			code:     "138",
+			accNo:    1234567890123450,
+			ifsc:     "CBIN0123461",
+			bank:     "CBI",
+			email:    "abc@gmail.com",
+			mobile:   9123456800,
+			category: "Employee",
+			wantErr:  ErrDuplicateEmail,
 		},
 		{
-			name: "duplicate mobile",
-			duplicate: func() *payee {
-				p, err := NewPayee("Xyz", "137", 9876543210987654, "CBIN0123460", "CBI", "xyz@gmail.com", 9123456780, "Employee")
-				require.NoError(t, err)
-				return p
-			},
-			wantErr: ErrDuplicateMobile,
+			testName: "duplicate mobile",
+			nameArg:  "Xyz",
+			code:     "137",
+			accNo:    9876543210987654,
+			ifsc:     "CBIN0123460",
+			bank:     "CBI",
+			email:    "xyz@gmail.com",
+			mobile:   9123456780,
+			category: "Employee",
+			wantErr:  ErrDuplicateMobile,
 		},
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			duplicatePayee := tt.duplicate()
-			_, err := store.Insert(ctx, duplicatePayee)
+		t.Run(tt.testName, func(t *testing.T) {
+			dup, err := NewPayee(tt.nameArg, tt.code, tt.accNo, tt.ifsc, tt.bank, tt.email, tt.mobile, tt.category)
+			require.NoError(t, err)
+
+			_, err = store.Insert(ctx, dup)
 			require.ErrorIs(t, err, tt.wantErr)
 		})
 	}

--- a/payee/payeeDAO_test.go
+++ b/payee/payeeDAO_test.go
@@ -85,6 +85,30 @@ func TestInsertPayeeWithDuplicateAccountNumber(t *testing.T) {
 	_, err = store.Insert(ctx, duplicate)
 	require.ErrorIs(t, err, ErrDuplicateAccount)
 }
+
+func TestInsertPayeeWithDuplicateEmail(t *testing.T) {
+	db := setupTestDB(t)
+	store := PayeeDB(db)
+	ctx := context.Background()
+
+	original, err := NewPayee("Abc", "136", 1234567890123456, "CBIN0123459", "CBI", "abc@gmail.com", 9123456780, "Employee")
+	require.NoError(t, err, "failed to create original payee")
+
+	id, err := store.Insert(ctx, original)
+	require.NoError(t, err, "failed to insert original payee")
+
+	defer func() {
+		_, err := db.Exec("DELETE FROM payees WHERE id = $1", id)
+		assert.NoError(t, err, "failed to clean up original payee")
+	}()
+
+	duplicate, err := NewPayee("Pqr", "138", 1234567890123450, "CBIN0123461", "CBI", "abc@gmail.com", 9123456800, "Employee")
+	require.NoError(t, err, "failed to create duplicate payee")
+
+	_, err = store.Insert(ctx, duplicate)
+	require.ErrorIs(t, err, ErrDuplicateEmail, "expected ErrDuplicateEmail")
+}
+
 func TestGetPayeeByID(t *testing.T) {
 	db := setupTestDB(t)
 	store := PayeeDB(db)

--- a/payee/payeeDAO_test.go
+++ b/payee/payeeDAO_test.go
@@ -70,6 +70,21 @@ func TestInsertPayeeWithDuplicateCode(t *testing.T) {
 	_, err = store.Insert(ctx, duplicate)
 	require.ErrorIs(t, err, ErrDuplicateCode)
 }
+
+func TestInsertPayeeWithDuplicateAccountNumber(t *testing.T) {
+	db := setupTestDB(t)
+	store := PayeeDB(db)
+	ctx := context.Background()
+
+	original, _ := NewPayee("Abc", "136", 1234567890123456, "CBIN0123459", "CBI", "abc@gmail.com", 9123456780, "Employee")
+	id, err := store.Insert(ctx, original)
+	require.NoError(t, err)
+	defer db.Exec("DELETE FROM payees WHERE id = $1", id)
+
+	duplicate, _ := NewPayee("Xyz", "137", 1234567890123456, "CBIN0123460", "CBI", "x@gmail.com", 9123456790, "Employee")
+	_, err = store.Insert(ctx, duplicate)
+	require.ErrorIs(t, err, ErrDuplicateAccount)
+}
 func TestGetPayeeByID(t *testing.T) {
 	db := setupTestDB(t)
 	store := PayeeDB(db)

--- a/payee/payeeDAO_test.go
+++ b/payee/payeeDAO_test.go
@@ -56,7 +56,20 @@ func TestInsertPayee(t *testing.T) {
 	assert.Equal(t, p.mobile, mobile)
 	assert.Equal(t, p.payeeCategory, category)
 }
+func TestInsertPayeeWithDuplicateCode(t *testing.T) {
+	db := setupTestDB(t)
+	store := PayeeDB(db)
+	ctx := context.Background()
 
+	original, _ := NewPayee("Abc", "136", 1234567890123456, "CBIN0123459", "CBI", "abc@gmail.com", 9123456780, "Employee")
+	id, err := store.Insert(ctx, original)
+	require.NoError(t, err)
+	defer db.Exec("DELETE FROM payees WHERE id = $1", id)
+
+	duplicate, _ := NewPayee("Abc", "136", 1234567800123456, "CBIN0123459", "CBI", "abcd@gmail.com", 9127456780, "Employee")
+	_, err = store.Insert(ctx, duplicate)
+	require.ErrorIs(t, err, ErrDuplicateCode)
+}
 func TestGetPayeeByID(t *testing.T) {
 	db := setupTestDB(t)
 	store := PayeeDB(db)

--- a/payee/payeeDAO_test.go
+++ b/payee/payeeDAO_test.go
@@ -128,7 +128,7 @@ func TestInsertPayeeWithDuplicateValues(t *testing.T) {
 		{
 			testName: "duplicate mobile",
 			nameArg:  "Xyz",
-			code:     "137",
+			code:     "139",
 			accNo:    9876543210987654,
 			ifsc:     "CBIN0123460",
 			bank:     "CBI",

--- a/payee/payeeDAO_test.go
+++ b/payee/payeeDAO_test.go
@@ -26,6 +26,8 @@ func TestInsertPayee(t *testing.T) {
 	store := PayeeDB(db)
 	ctx := context.Background()
 
+	_, _ = db.Exec("TRUNCATE payees RESTART IDENTITY CASCADE")
+
 	p, err := NewPayee("Abc", "136", 1234567890123456, "CBIN0123459", "CBI", "abc@gmail.com", 9123456780, "Employee")
 	require.NoError(t, err, "failed to create payee")
 
@@ -61,7 +63,7 @@ func TestInsertPayeeWithDuplicateValues(t *testing.T) {
 	store := PayeeDB(db)
 	ctx := context.Background()
 
-	// Insert the original payee
+	_, _ = db.Exec("TRUNCATE payees RESTART IDENTITY CASCADE")
 	original, err := NewPayee("Abc", "136", 1234567890123456, "CBIN0123459", "CBI", "abc@gmail.com", 9123456780, "Employee")
 	require.NoError(t, err, "failed to create original payee")
 
@@ -128,6 +130,8 @@ func TestGetPayeeByID(t *testing.T) {
 	db := setupTestDB(t)
 	store := PayeeDB(db)
 	ctx := context.Background()
+
+	_, _ = db.Exec("TRUNCATE payees RESTART IDENTITY CASCADE")
 
 	var id int
 	err := db.QueryRow(`

--- a/payee/payeeDAO_test.go
+++ b/payee/payeeDAO_test.go
@@ -26,7 +26,8 @@ func TestInsertPayee(t *testing.T) {
 	store := PayeeDB(db)
 	ctx := context.Background()
 
-	_, _ = db.Exec("TRUNCATE payees RESTART IDENTITY CASCADE")
+	_, err := db.Exec("TRUNCATE payees RESTART IDENTITY CASCADE")
+	require.NoError(t, err, "failed to truncate table")
 
 	p, err := NewPayee("Abc", "136", 1234567890123456, "CBIN0123459", "CBI", "abc@gmail.com", 9123456780, "Employee")
 	require.NoError(t, err, "failed to create payee")
@@ -63,7 +64,9 @@ func TestInsertPayeeWithDuplicateValues(t *testing.T) {
 	store := PayeeDB(db)
 	ctx := context.Background()
 
-	_, _ = db.Exec("TRUNCATE payees RESTART IDENTITY CASCADE")
+	_, err := db.Exec("TRUNCATE payees RESTART IDENTITY CASCADE")
+	require.NoError(t, err, "failed to truncate table")
+
 	original, err := NewPayee("Abc", "136", 1234567890123456, "CBIN0123459", "CBI", "abc@gmail.com", 9123456780, "Employee")
 	require.NoError(t, err, "failed to create original payee")
 
@@ -152,10 +155,11 @@ func TestGetPayeeByID(t *testing.T) {
 	store := PayeeDB(db)
 	ctx := context.Background()
 
-	_, _ = db.Exec("TRUNCATE payees RESTART IDENTITY CASCADE")
+	_, err := db.Exec("TRUNCATE payees RESTART IDENTITY CASCADE")
+	require.NoError(t, err, "failed to truncate table")
 
 	var id int
-	err := db.QueryRow(`
+	err = db.QueryRow(`
 		INSERT INTO payees (beneficiary_name, beneficiary_code, account_number, ifsc_code, bank_name, email, mobile, payee_category)
 		VALUES ('Abc','136',1234567890123456,'CBIN0123459','CBI','abc@gmail.com',9123456780,'Employee')
 		RETURNING id`).Scan(&id)


### PR DESCRIPTION
### Purpose
Add unit tests for unique constraints on the payee table.

### Changes
- Added tests to verify that inserting a payee with duplicate account_number , mobile, email or beneficiary_code fails.
- Ensured all tests use table-driven approach for clarity.
- Updated test setup to isolate test DB changes.
